### PR TITLE
Revise prerequisites and licensing details for connectors

### DIFF
--- a/copilot-connectors/prerequisites.md
+++ b/copilot-connectors/prerequisites.md
@@ -7,17 +7,17 @@ ms.audience: Admin
 ms.topic: concept-article
 ms.service: copilot-connectors
 ms.localizationpriority: medium
-description: "Learn about the licensing requirements for deploying Copilot connectors in your organization."
-ms.date: 04/09/2026
+description: "Learn about the licensing requirements for deploying Microsoft 365 Copilot connectors in your organization."
+ms.date: 04/13/2026
 ---
 
 # Prerequisites for deploying connectors
 
 Microsoft 365 Copilot connectors enable your organization to bring external data into the intelligent experiences within Microsoft 365. This article describes the prerequisites required to deploy Copilot connectors in your organization.
 
-Copilot connectors are available to all organizations with Microsoft 365 licenses. The experiences that connector content surfaces in—such as Microsoft Search or Microsoft 365 Copilot—depend on your organization's licensing.
+Copilot connectors are available to all organizations with Microsoft 365 licenses. Access to experiences such as Microsoft 365 Copilot and Microsoft Search that surface connector content depends on your organization's licensing.
 
-Some prebuilt connectors also have unique prerequisites and setup steps. For more information, see the deployment guide for that connector.
+Some prebuilt connectors also have unique prerequisites and setup steps. For information about prerequisites and setup steps for specific connnectors, see the deployment guide in [Microsoft-built synced connectors](prebuilt-connectors-overview.md).
 
 ## Admin roles and access
 
@@ -35,7 +35,7 @@ To deploy connectors, you need access to the data source, including:
 
 ## Licensing and eligibility
 
-Copilot connectors work across multiple Microsoft 365 surfaces. The surfaces available to your users depend on your organization's licensing:
+Copilot connectors work across multiple Microsoft 365 surfaces. The surfaces available to your users depend on your organization's licensing.
 
 | License | Microsoft Search | Microsoft 365 Copilot grounding | Copilot Chat agents (grounded on connector data) |
 |---|---|---|---|
@@ -46,7 +46,6 @@ Copilot connectors work across multiple Microsoft 365 surfaces. The surfaces ava
 
 > [!NOTE]
 > Microsoft 365 Copilot is an add-on to Microsoft 365. If your organization has Microsoft 365 Copilot licenses, connector grounding in Copilot is included—no separate connector entitlement is required. Advanced features such as semantic search require at least one Microsoft 365 Copilot license in the tenant.
-
 
 For more information, see [Agent capabilities and licensing models](/microsoft-365/copilot/extensibility/prerequisites).
 

--- a/copilot-connectors/prerequisites.md
+++ b/copilot-connectors/prerequisites.md
@@ -15,6 +15,8 @@ ms.date: 04/09/2026
 
 Microsoft 365 Copilot connectors enable your organization to bring external data into the intelligent experiences within Microsoft 365. This article describes the prerequisites required to deploy Copilot connectors in your organization.
 
+Copilot connectors are available to all organizations with Microsoft 365 licenses. The experiences that connector content surfaces in—such as Microsoft Search or Microsoft 365 Copilot—depend on your organization's licensing.
+
 Some prebuilt connectors also have unique prerequisites and setup steps. For more information, see the deployment guide for that connector.
 
 ## Admin roles and access
@@ -31,14 +33,20 @@ To deploy connectors, you need access to the data source, including:
 - Configuration of the external environment (Google Cloud Project for Google Drive, Confluence site URL). For information about the configuration details for specific connectors, see the deployment guide for that connector.
 - Permissions to access the content you want indexed (wiki pages, catalog items, meeting transcripts, and so on).
 
-## Copilot Studio and agent licensing
+## Licensing and eligibility
 
-If you're using Copilot Studio to build agents that use connectors, you need either:
+Copilot connectors work across multiple Microsoft 365 surfaces. The surfaces available to your users depend on your organization's licensing:
 
-- A Copilot Studio license
-- Usage billing (pay-as-you-go) set up in the tenant
+| License | Microsoft Search | Microsoft 365 Copilot grounding | Copilot Chat agents (grounded on connector data) |
+|---|---|---|---|
+| Microsoft 365 (any plan) | ✅ | ❌ | ❌ |
+| Microsoft 365 + Microsoft 365 Copilot add-on | ✅ | ✅ | ✅ |
+| Copilot Studio license | ✅ | ❌ | ✅ |
+| Usage billing (pay-as-you-go) enabled in tenant | ✅ | ❌ | ✅ |
 
-Advanced features like semantic search require the maker to have a Microsoft 365 Copilot license in the tenant.
+> [!NOTE]
+> Microsoft 365 Copilot is an add-on to Microsoft 365. If your organization has Microsoft 365 Copilot licenses, connector grounding in Copilot is included—no separate connector entitlement is required. Advanced features such as semantic search require at least one Microsoft 365 Copilot license in the tenant.
+
 
 For more information, see [Agent capabilities and licensing models](/microsoft-365/copilot/extensibility/prerequisites).
 

--- a/copilot-connectors/prerequisites.md
+++ b/copilot-connectors/prerequisites.md
@@ -17,7 +17,7 @@ Microsoft 365 Copilot connectors enable your organization to bring external data
 
 Copilot connectors are available to all organizations with Microsoft 365 licenses. Access to experiences such as Microsoft 365 Copilot and Microsoft Search that surface connector content depends on your organization's licensing.
 
-Some prebuilt connectors also have unique prerequisites and setup steps. For information about prerequisites and setup steps for specific connnectors, see the deployment guide in [Microsoft-built synced connectors](prebuilt-connectors-overview.md).
+Some prebuilt connectors also have unique prerequisites and setup steps. For information about prerequisites and setup steps for specific connectors, see the deployment guide in [Microsoft-built synced connectors](prebuilt-connectors-overview.md).
 
 ## Admin roles and access
 


### PR DESCRIPTION
Updated licensing information and prerequisites for Copilot connectors, including details on Microsoft 365 plans and Copilot Studio usage.


