### PR TITLE
Add note about custom synced connector option for Salesforce CRM

### DIFF
--- a/copilot-connectors/salesforce-crm-overview.md
+++ b/copilot-connectors/salesforce-crm-overview.md
@@ -85,7 +85,7 @@ The Salesforce CRM connector has the following limitations:
 - **Comments and attachments not indexed by default** - Comments and attachments on records are in private preview. Because this content can introduce noise that affects core use cases, it is not included by default. Admins can selectively enable comments and attachments in the **Manage properties** section.
 - **API usage during crawls** - Full crawls consume Salesforce API quota. Consider scheduling full crawls during off-peak hours or weekends, especially for orgs with large record volumes, to avoid impacting daily operations or exhausting API limits.
 
-If your scenario needs objects or fields not covered by the connector's default behavior, you can build a custom synced connector using the [Copilot connectors API](/graph/connecting-external-content-connectors-api-overview). A reference implementation for Salesforce CRM is available at the [Salesforce Custom Copilot Connector](https://github.com/microsoft/Salesforce-Custom-Copilot-Connector) repo on GitHub.
+If your scenario needs objects or fields not covered by the connector's default behavior, you can build a custom synced connector using the [Copilot connectors API](/graph/connecting-external-content-connectors-api-overview). A reference implementation for Salesforce CRM is available at the [Salesforce custom Copilot connector](https://github.com/microsoft/Salesforce-Custom-Copilot-Connector) repo on GitHub.
 
 ## Data types indexed from Salesforce CRM
 

--- a/copilot-connectors/salesforce-crm-overview.md
+++ b/copilot-connectors/salesforce-crm-overview.md
@@ -85,6 +85,8 @@ The Salesforce CRM connector has the following limitations:
 - **Comments and attachments not indexed by default** - Comments and attachments on records are in private preview. Because this content can introduce noise that affects core use cases, it is not included by default. Admins can selectively enable comments and attachments in the **Manage properties** section.
 - **API usage during crawls** - Full crawls consume Salesforce API quota. Consider scheduling full crawls during off-peak hours or weekends, especially for orgs with large record volumes, to avoid impacting daily operations or exhausting API limits.
 
+If your scenario needs objects or fields not covered by the connector's default behavior, you can build a custom synced connector using the [Copilot connectors API](/graph/connecting-external-content-connectors-api-overview). A reference implementation for Salesforce CRM is available at the [Salesforce Custom Copilot Connector](https://github.com/microsoft/Salesforce-Custom-Copilot-Connector) repo on GitHub.
+
 ## Data types indexed from Salesforce CRM
 
 The Salesforce CRM connector indexes the following Salesforce objects so they can be used in Copilot, Copilot Search, and Microsoft Search.

--- a/copilot-connectors/salesforce-crm-troubleshooting.md
+++ b/copilot-connectors/salesforce-crm-troubleshooting.md
@@ -82,6 +82,8 @@ If custom fields you selected in the **Add Properties** panel aren't appearing i
 - Check that the connection completed at least one full crawl after you added the custom fields.
 - If you promoted the field to a schema property, verify that the property or queryable limit wasn't exceeded. Open the **Add Properties** panel and check the budget counters.
 
+If your scenario needs objects or fields not covered by the connector's default behavior, you can build a custom synced connector using the [Copilot connectors API](/graph/connecting-external-content-connectors-api-overview). A reference implementation for Salesforce CRM is available at the [Salesforce Custom Copilot Connector](https://github.com/microsoft/Salesforce-Custom-Copilot-Connector) repo on GitHub.
+
 ## Related content
 
 - [Salesforce CRM connector overview](salesforce-crm-overview.md)

--- a/copilot-connectors/salesforce-crm-troubleshooting.md
+++ b/copilot-connectors/salesforce-crm-troubleshooting.md
@@ -82,7 +82,7 @@ If custom fields you selected in the **Add Properties** panel aren't appearing i
 - Check that the connection completed at least one full crawl after you added the custom fields.
 - If you promoted the field to a schema property, verify that the property or queryable limit wasn't exceeded. Open the **Add Properties** panel and check the budget counters.
 
-If your scenario needs objects or fields not covered by the connector's default behavior, you can build a custom synced connector using the [Copilot connectors API](/graph/connecting-external-content-connectors-api-overview). A reference implementation for Salesforce CRM is available at the [Salesforce Custom Copilot Connector](https://github.com/microsoft/Salesforce-Custom-Copilot-Connector) repo on GitHub.
+If your scenario needs objects or fields not covered by the connector's default behavior, you can build a custom synced connector using the [Copilot connectors API](/graph/connecting-external-content-connectors-api-overview). A reference implementation for Salesforce CRM is available at the [Salesforce custom Copilot connector](https://github.com/microsoft/Salesforce-Custom-Copilot-Connector) repo on GitHub.
 
 ## Related content
 


### PR DESCRIPTION
## Summary

Adds a brief reference to the [Copilot connectors API](/graph/connecting-external-content-connectors-api-overview) and the open-source [Salesforce Custom Copilot Connector](https://github.com/microsoft/Salesforce-Custom-Copilot-Connector) reference implementation in two Salesforce CRM doc pages.

The note serves as an off-ramp for customers whose scenario isn't fully covered by the OOB connector's default behavior (additional standard/extended objects, broader custom-field support, custom-object indexing, etc.).

## Files changed

- `copilot-connectors/salesforce-crm-overview.md` — appended a non-bullet paragraph at the end of the **Limitations** section.
- `copilot-connectors/salesforce-crm-troubleshooting.md` — appended a paragraph at the end of the **Custom fields not appearing in search results** topic, before *Related content*.

Both additions use identical wording so the off-ramp reads consistently across pages.

## Wording (same in both files)

> If your scenario needs objects or fields not covered by the connector's default behavior, you can build a custom synced connector using the [Copilot connectors API](/graph/connecting-external-content-connectors-api-overview). A reference implementation for Salesforce CRM is available at the [Salesforce Custom Copilot Connector](https://github.com/microsoft/Salesforce-Custom-Copilot-Connector) repo on GitHub.

## Test plan

- [x] Local Markdown preview confirms both insertions render cleanly in place.
- [x] Both links use the docs-relative form for in-site references (`/graph/...`) and the full URL for the external GitHub repo.