### PR TITLE
Add Salesforce custom CRM sample page under Build custom synced connectors

### DIFF
--- a/copilot-connectors/TOC.yml
+++ b/copilot-connectors/TOC.yml
@@ -666,6 +666,8 @@ items:
         href: /graph/connecting-external-content-manage-items?toc=/microsoft-365/copilot/connectors/toc.json&bc=/microsoft-365/copilot/connectors/breadcrumb/m365-copilot-connectors/toc.json
       - name: Use external groups
         href: /graph/connecting-external-content-external-groups?toc=/microsoft-365/copilot/connectors/toc.json&bc=/microsoft-365/copilot/connectors/breadcrumb/m365-copilot-connectors/toc.json
+    - name: Salesforce custom CRM sample
+      href: salesforce-custom-connector-sample.md
     - name: Delegate connector administration
       href: /microsoft-365/copilot/extensibility/connector-admin-delegation?toc=/microsoft-365/copilot/connectors/toc.json&bc=/microsoft-365/copilot/connectors/breadcrumb/m365-copilot-connectors/toc.json
 - name: Set up federated connectors

--- a/copilot-connectors/salesforce-custom-connector-sample.md
+++ b/copilot-connectors/salesforce-custom-connector-sample.md
@@ -1,0 +1,41 @@
+---
+ms.date: 06/20/2026
+title: "Build a custom Salesforce CRM connector"
+ms.author: anparanjape
+author: anparanjape
+ms.topic: article
+ms.service: copilot-connectors
+ms.localizationpriority: medium
+description: "Reference implementation of a custom Microsoft 365 Copilot connector for Salesforce CRM."
+---
+
+# Build a custom Salesforce CRM connector
+
+The Microsoft 365 Copilot Salesforce CRM custom synced connector sample is a Python reference implementation that shows how to use the [Copilot connectors API](/graph/connecting-external-content-connectors-api-overview) to ingest Salesforce CRM data into Microsoft Graph. Use the sample as a starting point when the [out-of-box Salesforce CRM connector](salesforce-crm-overview.md) doesn't cover your scenario — for example, when you need to index custom objects or standard objects beyond the OOB connector's default set.
+
+The sample is published as open source at [microsoft/Salesforce-Custom-Copilot-Connector](https://github.com/microsoft/Salesforce-Custom-Copilot-Connector). Fork the repository and customize it for your organization's Salesforce schema. The repository's `README.md` covers prerequisites, architecture, deployment commands, and configuration in detail.
+
+## When to use the sample
+
+Consider the sample when your scenario requires:
+
+- **Custom objects** — Salesforce objects ending in `__c` that the OOB connector doesn't index.
+- **Standard objects beyond the OOB set** — for example, Campaign, FeedItem, Order, Quote, or OpportunityLineItem. The sample supports these in addition to Account, Contact, Lead, Opportunity, and Case.
+- **Broader custom-field coverage** — surfacing more custom fields than the OOB connector exposes through its **Add Properties** experience.
+
+## Customize the sample for your Salesforce org
+
+The main files to edit are:
+
+- **`config/schema.json`** — defines which Salesforce objects and fields are fetched per object type. Add entries for your custom objects (`__c`) and custom fields.
+- **`config/graph-schema.json`** — defines the Microsoft Graph property schema your items will use: property names, types, flags (`isSearchable`, `isQueryable`, `isRetrievable`, `isRefinable`), and semantic labels.
+- **`config/template.json`** — the Adaptive Card template used to render the sample's items as Microsoft Search results.
+- **`env/.env.local`** — connector ID, connection name, connection description, Salesforce instance URL, and tuning parameters. Secrets go in `env/.env.local.user`.
+
+For step-by-step configuration and deployment instructions, see the repository's `README.md`.
+
+## Related content
+
+- [Salesforce CRM connector overview](salesforce-crm-overview.md)
+- [Copilot connectors API overview](/graph/connecting-external-content-connectors-api-overview)
+- [Enhance Copilot discovery of connectors content](enhance-copilot-discovery.md)


### PR DESCRIPTION
## Summary

Adds a new conceptual page `salesforce-custom-connector-sample.md` describing the open-source Salesforce CRM custom connector sample at [microsoft/Salesforce-Custom-Copilot-Connector](https://github.com/microsoft/Salesforce-Custom-Copilot-Connector), plus a TOC entry under **Build custom synced connectors** with the label **Salesforce custom CRM sample**.

The page covers:

- **When to use the sample** — custom objects, extended standard objects (Campaign, FeedItem, Order, Quote, OpportunityLineItem), and broader custom-field coverage.
- **How to customize the sample** — the four main files to edit (`config/schema.json`, `config/graph-schema.json`, `config/template.json`, `env/.env.local`).

Prerequisites, architecture, and deployment steps are intentionally deferred to the sample repository's `README.md` to keep the docs page short and the sample repo as the single source of truth for implementation specifics.

## Files changed

- New: `copilot-connectors/salesforce-custom-connector-sample.md` (~40 lines)
- Modified: `copilot-connectors/TOC.yml` (2-line insert under the existing `Build custom synced connectors` group, between `Use the Copilot connectors API` and `Delegate connector administration`)

## Related PRs

- **PR #68**: adds cross-reference notes from the OOB Salesforce CRM overview (limitations section) and troubleshooting page ("Custom fields not appearing") pointing to the sample repo on GitHub. Once both this PR and #68 merge, a small follow-up PR will update those cross-references to link to this new in-docs page first.

## Test plan

- [x] Local Markdown preview confirms the page renders cleanly.
- [x] TOC entry sits at the correct indent level — sibling of `Build with Agents Toolkit`, `Build with SDK`, `Use the Copilot connectors API`, and `Delegate connector administration`.
- [x] All internal links use the docs-relative form (`salesforce-crm-overview.md`, `/graph/connecting-external-content-connectors-api-overview`, etc.). External link to the sample repo uses the full URL.
- [ ] Acrolinx pass on Build validation
- [ ] Docs reviewer sign-off

## Author

@Anshuman2702 — published the public sample repo at microsoft/Salesforce-Custom-Copilot-Connector last week and is opening this PR so customers can find the sample from the connector docs.